### PR TITLE
Fix packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from pkgutil import walk_packages
 def get_packages():
     return [name
             for _, name, ispkg in walk_packages(".")
-            if name.startswith("src") and ispkg]
+            if ispkg]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkgutil import walk_packages
 
 def get_packages():
     return [name
-            for _, name, ispkg in walk_packages(".")
+            for _, name, ispkg in walk_packages([])
             if ispkg]
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pkgutil import walk_packages
 
 def get_packages():
     return [name
-            for _, name, ispkg in walk_packages([])
+            for _, name, ispkg in walk_packages(['.'])
             if ispkg]
 
 


### PR DESCRIPTION
Currently it is not possible to install pysesame2 since `python setup.py install` does not work, as "src" folder does not exist (or was renamed?)

Fixing this correctly generates the egg:

```
unzip -l venv/lib/python3.6/site-packages/pysesame2-1.0.0-py3.6.egg
Archive:  venv/lib/python3.6/site-packages/pysesame2-1.0.0-py3.6.egg
  Length      Date    Time    Name
---------  ---------- -----   ----
      552  2019-04-04 16:41   EGG-INFO/PKG-INFO
      280  2019-04-04 16:41   EGG-INFO/SOURCES.txt
        1  2019-04-04 16:41   EGG-INFO/dependency_links.txt
       48  2019-04-04 16:41   EGG-INFO/entry_points.txt
        9  2019-04-04 16:41   EGG-INFO/requires.txt
       10  2019-04-04 16:41   EGG-INFO/top_level.txt
        1  2019-04-04 16:41   EGG-INFO/zip-safe
      219  2019-04-04 16:38   pysesame2/__init__.py
     3338  2019-04-04 16:38   pysesame2/cli.py
     5069  2019-04-04 16:38   pysesame2/pysesame2.py
      353  2019-04-04 16:41   pysesame2/__pycache__/__init__.cpython-36.pyc
     2921  2019-04-04 16:41   pysesame2/__pycache__/cli.cpython-36.pyc
     5563  2019-04-04 16:41   pysesame2/__pycache__/pysesame2.cpython-36.pyc
---------                     -------
    18364                     13 files
```

And also allow users to do pip install git+https://github.com/yagami-cerberus/pysesame2.git
